### PR TITLE
Include instructions for installing a browse

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Install dependencies
   npm install
 ```
 
+Install a browser
+```bash
+npx playwright install
+```
+
 Start the server
 
 ```bash


### PR DESCRIPTION
Playwright requires a browser to be installed, this command installs one. The CLI does prompt users to install one but it should still be included in the readme for those extra special people. 